### PR TITLE
In some cases docker ADD can fail due to a TLS timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ARG bx_dev_userid=1000
 # RUN apt-get update && apt-get dist-upgrade -y
 
 # Add utils files
-ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/run-utils.sh /swift-utils/run-utils.sh
-ADD https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh /swift-utils/common-utils.sh
+RUN curl -sL https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/run-utils.sh -o /swift-utils/run-utils.sh
+RUN curl -sL https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh -o /swift-utils/common-utils.sh
 RUN chmod -R 555 /swift-utils
 
 # Create user if not root

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM ibmcom/swift-ubuntu-runtime:4.1.1
 LABEL maintainer="IBM Swift Engineering at IBM Cloud"
 LABEL Description="Template Dockerfile that extends the ibmcom/swift-ubuntu-runtime image."
 
+RUN apt-get update \
+&& apt-get install -y curl \
+&& rm -rf /var/lib/apt/lists/*
+
 # We can replace this port with what the user wants
 EXPOSE 8080
 
@@ -13,9 +17,10 @@ ARG bx_dev_userid=1000
 # RUN apt-get update && apt-get dist-upgrade -y
 
 # Add utils files
-RUN curl -sL https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/run-utils.sh -o /swift-utils/run-utils.sh
-RUN curl -sL https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh -o /swift-utils/common-utils.sh
-RUN chmod -R 555 /swift-utils
+RUN mkdir /swift-utils \
+&& curl -sL https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/run-utils.sh -o /swift-utils/run-utils.sh \
+&& curl -sL https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/common-utils.sh -o /swift-utils/common-utils.sh \
+&& chmod -R 555 /swift-utils
 
 # Create user if not root
 RUN if [ $bx_dev_user != "root" ]; then useradd -ms /bin/bash -u $bx_dev_userid $bx_dev_user; fi


### PR DESCRIPTION
Docker build output:
```
ADD failed: Get https://raw.githubusercontent.com/IBM-Swift/swift-ubuntu-docker/master/utils/tools-utils.sh: net/http: TLS handshake timeout
```

Use curl to download the file to avoid the handshake timeout.